### PR TITLE
fix: pass `transformer` to srcset generate function

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -426,6 +426,7 @@ export function transformProps<
       aspectRatio,
       layout,
       breakpoints,
+      transformer,
     });
 
     if (layout === "fullWidth" || layout === "constrained") {


### PR DESCRIPTION
When using a custom transform the `getSrcSet` is not using the custom one that we pass on the `transformer` prop, with this change, if we pass a custom transformer the function can use it