### PR TITLE
fix(svelte): remove obsolete typesVersions

### DIFF
--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -36,15 +36,5 @@
       "svelte": "./dist/index.js"
     },
     "./package.json": "./package.json"
-  },
-  "typesVersions": {
-    ">4.0": {
-      "image.svelte": [
-        "./dist/image.d.ts"
-      ],
-      "index": [
-        "./dist/index.d.ts"
-      ]
-    }
   }
 }


### PR DESCRIPTION
This field is only needed if you have more than one entry point, which this package doesn't have.

Great library btw 🙌 