### PR TITLE
fix(core): fix aspect ratio calculation for srcset

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -301,7 +301,7 @@ export const getSrcSet = ({
     .map((bp) => {
       let transformedHeight;
       if (height && aspectRatio) {
-        transformedHeight = Math.round(bp * aspectRatio);
+        transformedHeight = Math.round(bp / aspectRatio);
       }
       // Not sure why TS isn't narrowing the type here
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion


### PR DESCRIPTION
Currently the aspect ratio is being incorrectly calculated as it's inverting it to the opposite of what's desired.

Reproduction: https://codesandbox.io/s/unpic-img-incorrect-aspect-ratio-nblkgn

Fixes #53 