### PR TITLE
chore: setup prettier-plugin-svelte

### DIFF
--- a/packages/svelte/.prettierrc
+++ b/packages/svelte/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "plugins": ["prettier-plugin-svelte"],
+  "pluginSearchDirs": ["."],
+  "overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }]
+}

--- a/packages/svelte/CHANGELOG.md
+++ b/packages/svelte/CHANGELOG.md
@@ -2,63 +2,58 @@
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @unpic/core bumped to 0.0.8
+- The following workspace dependencies were updated
+  - dependencies
+    - @unpic/core bumped to 0.0.8
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @unpic/core bumped to 0.0.10
+- The following workspace dependencies were updated
+  - dependencies
+    - @unpic/core bumped to 0.0.10
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @unpic/core bumped to 0.0.11
+- The following workspace dependencies were updated
+  - dependencies
+    - @unpic/core bumped to 0.0.11
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @unpic/core bumped to 0.0.12
+- The following workspace dependencies were updated
+  - dependencies
+    - @unpic/core bumped to 0.0.12
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @unpic/core bumped to 0.0.13
+- The following workspace dependencies were updated
+  - dependencies
+    - @unpic/core bumped to 0.0.13
 
 ## [0.0.7](https://github.com/ascorbic/unpic-img/compare/svelte-v0.0.6...svelte-v0.0.7) (2023-02-25)
 
-
 ### Features
 
-* **webc:** add WebC/11ty support ([#49](https://github.com/ascorbic/unpic-img/issues/49)) ([be3056f](https://github.com/ascorbic/unpic-img/commit/be3056fdf3e87b382fb86ade74b0d1d3247072bd))
-
+- **webc:** add WebC/11ty support ([#49](https://github.com/ascorbic/unpic-img/issues/49)) ([be3056f](https://github.com/ascorbic/unpic-img/commit/be3056fdf3e87b382fb86ade74b0d1d3247072bd))
 
 ### Bug Fixes
 
-* **svelte:** remove obsolete typesVersions ([#43](https://github.com/ascorbic/unpic-img/issues/43)) ([a55f9d1](https://github.com/ascorbic/unpic-img/commit/a55f9d15a455989f0b28b40e55367f98e9a10f0e))
-
+- **svelte:** remove obsolete typesVersions ([#43](https://github.com/ascorbic/unpic-img/issues/43)) ([a55f9d1](https://github.com/ascorbic/unpic-img/commit/a55f9d15a455989f0b28b40e55367f98e9a10f0e))
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @unpic/core bumped to 0.0.9
+- The following workspace dependencies were updated
+  - dependencies
+    - @unpic/core bumped to 0.0.9
 
 ## [0.0.5](https://github.com/ascorbic/unpic-img/compare/svelte-v0.0.4...svelte-v0.0.5) (2023-02-21)
 
-
 ### Features
 
-* add svelte and fix types ([7f9f428](https://github.com/ascorbic/unpic-img/commit/7f9f428bd66226ea9a3ddefc8f5908b58c2bb7ac))
-
+- add svelte and fix types ([7f9f428](https://github.com/ascorbic/unpic-img/commit/7f9f428bd66226ea9a3ddefc8f5908b58c2bb7ac))
 
 ### Dependencies
 
-* The following workspace dependencies were updated
-  * dependencies
-    * @unpic/core bumped to 0.0.7
+- The following workspace dependencies were updated
+  - dependencies
+    - @unpic/core bumped to 0.0.7

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -33,7 +33,6 @@ npm install @unpic/svelte
   height={600}
   alt="A lovely bath"
 />
-
 ```
 
 For the supported props, see [the main README](https://github.com/ascorbic/unpic-img/#props).

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -14,12 +14,16 @@
     "build": "svelte-kit sync && svelte-package",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+    "lint": "prettier --plugin-search-dir . --check .",
+    "format": "prettier --plugin-search-dir . --write .",
     "prepublishOnly": "yarn build"
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "^2.0.0",
     "@sveltejs/kit": "^1.5.0",
     "@sveltejs/package": "^2.0.0",
+    "prettier": "^2.8.3",
+    "prettier-plugin-svelte": "^2.8.1",
     "svelte": "^3.54.0",
     "svelte-check": "^3.0.1",
     "tslib": "^2.4.1",

--- a/packages/svelte/src/app.html
+++ b/packages/svelte/src/app.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<meta charset="utf-8" />
-		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		%sveltekit.head%
-	</head>
-	<body>
-		<div>%sveltekit.body%</div>
-	</body>
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%sveltekit.assets%/favicon.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    %sveltekit.head%
+  </head>
+  <body>
+    <div>%sveltekit.body%</div>
+  </body>
 </html>

--- a/packages/svelte/src/lib/image.svelte
+++ b/packages/svelte/src/lib/image.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-    import { transformProps, type UnpicImageProps } from "@unpic/core"
-    import type {HTMLImgAttributes} from "svelte/elements"
-    import styleToCss from 'style-object-to-css-string';
-    type $$Props = UnpicImageProps<HTMLImgAttributes, string | null>
-    const { style: parentStyle, ...props} = $$props as $$Props
-    const {alt, style: styleObj, ...transformedProps} = transformProps({...props, style: {} as Record<string, string>})
-    const style = [styleToCss(styleObj), parentStyle].filter(Boolean).join(';')
+  import { transformProps, type UnpicImageProps } from "@unpic/core"
+  import styleToCss from 'style-object-to-css-string';
+  import type { HTMLImgAttributes } from "svelte/elements"
 
-  </script>
-  <img alt={alt} style={style} {...transformedProps} />
+  type $$Props = UnpicImageProps<HTMLImgAttributes, string | null>
+
+  const { style: parentStyle, ...props } = $$props as $$Props
+  const { alt, style: styleObj, ...transformedProps } = transformProps({...props, style: {} as Record<string, string>})
+  const style = [styleToCss(styleObj), parentStyle].filter(Boolean).join(';')
+</script>
+<img {alt} {style} {...transformedProps} />

--- a/packages/svelte/svelte.config.js
+++ b/packages/svelte/svelte.config.js
@@ -1,15 +1,15 @@
-import adapter from '@sveltejs/adapter-auto';
-import { vitePreprocess } from '@sveltejs/kit/vite';
+import adapter from "@sveltejs/adapter-auto";
+import { vitePreprocess } from "@sveltejs/kit/vite";
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	// Consult https://kit.svelte.dev/docs/integrations#preprocessors
-	// for more information about preprocessors
-	preprocess: vitePreprocess(),
+  // Consult https://kit.svelte.dev/docs/integrations#preprocessors
+  // for more information about preprocessors
+  preprocess: vitePreprocess(),
 
-	kit: {
-		adapter: adapter()
-	}
+  kit: {
+    adapter: adapter(),
+  },
 };
 
 export default config;

--- a/packages/svelte/tsconfig.json
+++ b/packages/svelte/tsconfig.json
@@ -1,17 +1,17 @@
 {
-	"extends": "./.svelte-kit/tsconfig.json",
-	"compilerOptions": {
-		"allowJs": true,
-		"checkJs": true,
-		"esModuleInterop": true,
-		"forceConsistentCasingInFileNames": true,
-		"resolveJsonModule": true,
-		"skipLibCheck": true,
-		"sourceMap": true,
-		"strict": true
-	}
-	// Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
-	//
-	// If you want to overwrite includes/excludes, make sure to copy over the relevant includes/excludes
-	// from the referenced tsconfig.json - TypeScript does not merge them in
+  "extends": "./.svelte-kit/tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true
+  }
+  // Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
+  //
+  // If you want to overwrite includes/excludes, make sure to copy over the relevant includes/excludes
+  // from the referenced tsconfig.json - TypeScript does not merge them in
 }

--- a/packages/svelte/vite.config.ts
+++ b/packages/svelte/vite.config.ts
@@ -1,6 +1,6 @@
-import { sveltekit } from '@sveltejs/kit/vite';
-import { defineConfig } from 'vite';
+import { sveltekit } from "@sveltejs/kit/vite";
+import { defineConfig } from "vite";
 
 export default defineConfig({
-	plugins: [sveltekit()]
+  plugins: [sveltekit()],
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6164,6 +6164,8 @@ __metadata:
     "@sveltejs/kit": ^1.5.0
     "@sveltejs/package": ^2.0.0
     "@unpic/core": "workspace:^"
+    prettier: ^2.8.3
+    prettier-plugin-svelte: ^2.8.1
     style-object-to-css-string: ^1.0.1
     svelte: ^3.54.0
     svelte-check: ^3.0.1
@@ -22344,6 +22346,16 @@ __metadata:
     sass-formatter: ^0.7.5
     synckit: ^0.8.4
   checksum: b4b8515d1f31984d6856783eb0163020a26c106284f01b59870b09110f1310aa916328f1622a7a9cd87b229c482ff5cb283bcbdad1b6a8816fabea9e1341a808
+  languageName: node
+  linkType: hard
+
+"prettier-plugin-svelte@npm:^2.8.1":
+  version: 2.9.0
+  resolution: "prettier-plugin-svelte@npm:2.9.0"
+  peerDependencies:
+    prettier: ^1.16.4 || ^2.0.0
+    svelte: ^3.2.0
+  checksum: 2d74a960783a1974a4818ebac25145ee26095c5652a777584b7eb8f08907702160263538396c03dce7f9bcd5b313f914b234eb809ccc1550a5933fc5e919ca88
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Can't declare variables with `const` in Svelte or they won't be reactive. You need to use `$:`