### PR TITLE
chore: add support for package provenance

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -23,6 +23,9 @@
     "@unpic/core": "workspace:^",
     "tslib": "^2.5.0"
   },
+  "publishConfig": {
+    "provenance": true
+  },
   "module": "dist/fesm2015/unpic-angular.mjs",
   "typings": "dist/index.d.ts",
   "es2020": "dist/fesm2020/unpic-angular.mjs",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -19,6 +19,9 @@
   "keywords": [
     "astro"
   ],
+  "publishConfig": {
+    "provenance": true
+  },
   "devDependencies": {
     "astro": "^2.1.3"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,6 +16,9 @@
     "prepublishOnly": "pnpm clean && pnpm build",
     "test": "vitest run"
   },
+  "publishConfig": {
+    "provenance": true
+  },
   "devDependencies": {
     "tsup": "^6.7.0"
   },

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -22,6 +22,9 @@
       "import": "./dist/index.mjs"
     }
   },
+  "publishConfig": {
+    "provenance": true
+  },
   "scripts": {
     "test": "vitest run",
     "build": "tsup src/index.ts --format cjs,esm --dts --clean",

--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -41,6 +41,9 @@
     "start": "vite --open --mode ssr",
     "qwik": "qwik"
   },
+  "publishConfig": {
+    "provenance": true
+  },
   "devDependencies": {
     "@builder.io/qwik": "0.23.0",
     "@types/eslint": "8.37.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -34,6 +34,9 @@
     "publint": "publint",
     "test": "vitest run"
   },
+  "publishConfig": {
+    "provenance": true
+  },
   "devDependencies": {
     "@testing-library/react": "^14.0.0",
     "@types/node": "^18.15.11",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -44,6 +44,9 @@
   "peerDependencies": {
     "solid-js": "^1.6.0"
   },
+  "publishConfig": {
+    "provenance": true
+  },
   "devDependencies": {
     "esbuild": "^0.17.12",
     "esbuild-plugin-solid": "^0.5.0",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -39,6 +39,9 @@
   "peerDependencies": {
     "svelte": "*"
   },
+  "publishConfig": {
+    "provenance": true
+  },
   "files": [
     "dist"
   ],

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,6 +22,9 @@
       "import": "./dist/image.js"
     }
   },
+  "publishConfig": {
+    "provenance": true
+  },
   "scripts": {
     "dev": "vite",
     "test": "vitest run",

--- a/packages/webc/package.json
+++ b/packages/webc/package.json
@@ -21,6 +21,9 @@
   "peerDependencies": {
     "@11ty/webc": ">=0.9.0"
   },
+  "publishConfig": {
+    "provenance": true
+  },
   "scripts": {
     "test": "# vitest run"
   },


### PR DESCRIPTION
Adds support for [package provencance](https://github.blog/2023-04-19-introducing-npm-package-provenance/). I'm not sure if it will work with pnpm, but there's only one way to find out!