### PR TITLE
fix(react): correctly handle aria and data attributes

### DIFF
--- a/packages/react/src/camelize.ts
+++ b/packages/react/src/camelize.ts
@@ -1,11 +1,15 @@
 import type { HTMLAttributes } from "react";
-
-const camelize = (s: string) =>
-  s.replace(/-./g, (substr) => substr[1].toUpperCase());
-
 const nestedKeys = new Set(["style"]);
 const fixedMap: Record<string, string> = {
   srcset: "srcSet",
+};
+const camelize = (key: string) => {
+  if (key.startsWith("data-") || key.startsWith("aria-")) {
+    return key;
+  }
+  return (
+    fixedMap[key] || key.replace(/-./g, (suffix) => suffix[1].toUpperCase())
+  );
 };
 
 export function camelizeProps<TObject extends HTMLAttributes<HTMLElement>>(
@@ -13,7 +17,7 @@ export function camelizeProps<TObject extends HTMLAttributes<HTMLElement>>(
 ): TObject {
   return Object.fromEntries(
     Object.entries(props).map(([k, v]) => [
-      fixedMap[k] || camelize(k),
+      camelize(k),
       nestedKeys.has(k) && v && typeof v !== "string" ? camelizeProps(v) : v,
     ])
   ) as TObject;

--- a/packages/react/test/react.test.tsx
+++ b/packages/react/test/react.test.tsx
@@ -15,4 +15,21 @@ describe("the React component", () => {
       expectPropsToMatchTransformed(img, props);
     });
   }
+
+  test(`renders an image with data and aria attributes`, () => {
+    const props = {
+      "aria-label": "A cool image",
+      "data-foo": "bar",
+      "data-ok": true,
+      ...testCases[0],
+    };
+
+    render(<Image {...props} />);
+    const img = screen.getByAltText<HTMLImageElement>(props.alt);
+    expect(img).toBeTruthy();
+    expect(img.dataset.foo).toBe("bar");
+    expect(img.dataset.ok).toBe("true");
+    expect(img.getAttribute("aria-label")).toBe("A cool image");
+    expectPropsToMatchTransformed(img, props);
+  });
 });


### PR DESCRIPTION
React treats `data-` and `aria-` attributes differently from other attributes, which it camel-cases. This PR ensures we special-case these. Fixes #215