### PR TITLE
fix(core): pass cdn prop to srcset

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -440,6 +440,7 @@ export function transformProps<
       layout,
       breakpoints,
       transformer,
+      cdn,
     });
 
     const transformed = transformer({ url, width, height });


### PR DESCRIPTION
Ensure than when the cdn is explicitly passed to the component that it is forwarded to getSrcSet

Fixes #228