### PR TITLE
fix(svelte): generate types for svelte component

### DIFF
--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -34,7 +34,8 @@
   "type": "module",
   "dependencies": {
     "@unpic/core": "workspace:^",
-    "style-object-to-css-string": "^1.0.1"
+    "style-object-to-css-string": "^1.0.1",
+    "unpic": "^3.6.1"
   },
   "peerDependencies": {
     "svelte": "*"

--- a/packages/svelte/src/lib/image.svelte
+++ b/packages/svelte/src/lib/image.svelte
@@ -1,12 +1,19 @@
 <script lang="ts">
-  import { transformProps, type UnpicImageProps } from "@unpic/core"
-  import styleToCss from 'style-object-to-css-string';
-  import type { HTMLImgAttributes } from "svelte/elements"
+  import { transformProps } from "@unpic/core";
+  import styleToCss from "style-object-to-css-string";
+  import type { ImageProps as BaseImageProps } from "./types";
+  // This unused import is a hack to get around a bug in svelte2tsx
+  import type { UrlTransformer, ImageCdn } from "unpic";
 
-  type $$Props = UnpicImageProps<HTMLImgAttributes, string | null>
+  type $$Props = BaseImageProps;
 
-  $: ({ style: parentStyle, ...props } = $$props as $$Props)
-  $: ({ alt, style: styleObj, ...transformedProps } = transformProps({...props, style: {} as Record<string, string>}))
-  $: style = [styleToCss(styleObj), parentStyle].filter(Boolean).join(';')
+  $: ({ style: parentStyle, ...props } = $$props as $$Props);
+  $: ({
+    alt,
+    style: styleObj,
+    ...transformedProps
+  } = transformProps({ ...props, style: {} as Record<string, string> }));
+  $: style = [styleToCss(styleObj), parentStyle].filter(Boolean).join(";");
 </script>
+
 <img {alt} {style} {...transformedProps} />

--- a/packages/svelte/src/lib/index.ts
+++ b/packages/svelte/src/lib/index.ts
@@ -1,2 +1,3 @@
 // Reexport your entry components here
 export { default as Image } from "./image.svelte";
+export type { ImageProps } from "./types";

--- a/packages/svelte/src/lib/types.ts
+++ b/packages/svelte/src/lib/types.ts
@@ -1,0 +1,4 @@
+import type { UnpicImageProps } from "@unpic/core";
+import type { HTMLImgAttributes } from "svelte/elements";
+
+export type ImageProps = UnpicImageProps<HTMLImgAttributes, string | null>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -688,6 +688,9 @@ importers:
       style-object-to-css-string:
         specifier: ^1.0.1
         version: 1.0.1
+      unpic:
+        specifier: ^3.6.1
+        version: 3.6.1
     devDependencies:
       '@sveltejs/adapter-auto':
         specifier: ^2.0.0
@@ -6789,7 +6792,7 @@ packages:
       kleur: 4.1.5
       sade: 1.8.1
       svelte: 3.58.0
-      svelte2tsx: 0.6.11(svelte@3.58.0)(typescript@5.0.4)
+      svelte2tsx: 0.6.15(svelte@3.58.0)(typescript@5.0.4)
     transitivePeerDependencies:
       - typescript
     dev: true
@@ -21770,10 +21773,10 @@ packages:
       typescript: 5.0.4
     dev: true
 
-  /svelte2tsx@0.6.11(svelte@3.58.0)(typescript@5.0.4):
-    resolution: {integrity: sha512-rRW/3V/6mcejYWmSqcHpmILOSPsOhLgkbKbrTOz82s2n8TywmIsqj2jYPsiL6HeGoUM/atiTD0YKguW4b7ECog==}
+  /svelte2tsx@0.6.15(svelte@3.58.0)(typescript@5.0.4):
+    resolution: {integrity: sha512-+j6RmA3g5pPs1DHa/rdzJjjhZuCfWx0IbNPaR99A2bvOSPPY6BlVkBGU0urI+DGcWHhYEG28Flo942KqlAkpEQ==}
     peerDependencies:
-      svelte: ^3.55
+      svelte: ^3.55 || ^4.0
       typescript: ^4.9.4 || ^5.0.0
     dependencies:
       dedent-js: 1.0.1


### PR DESCRIPTION
The Svelte compiler was swallowing an error which was preventing the image.svelte.d.ts file from being generated. The error was because of what seems to be a bug in the svelte2tsx compiler. This is fixed by importing, unused, the types needed from the unpic package.