### PR TITLE
fix(react): use extension for next deep imports

### DIFF
--- a/packages/react/src/next.tsx
+++ b/packages/react/src/next.tsx
@@ -1,10 +1,10 @@
 import { useContext, forwardRef, useMemo, useEffect } from "react";
 import type { ImageProps as UnpicImageProps } from "./index";
-import type { ImageConfigComplete } from "next/dist/shared/lib/image-config";
-import { imageConfigDefault } from "next/dist/shared/lib/image-config";
 import { Image as UnpicImage } from "./index";
-import { ImageConfigContext } from "next/dist/shared/lib/image-config-context";
 import { getImageCdnForUrl } from "unpic";
+import type { ImageConfigComplete } from "next/dist/shared/lib/image-config.js";
+import { imageConfigDefault } from "next/dist/shared/lib/image-config.js";
+import { ImageConfigContext } from "next/dist/shared/lib/image-config-context.js";
 
 //
 const configEnv = process.env


### PR DESCRIPTION
pnpm has trouble with deep imports that don't have include extensions when using pnpm. This adds `.js` to all of the deep imports from Next.js.

Fixes #118