### PR TITLE
fix(qwik): don't externalise `@unpic/core` dep

### DIFF
--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -48,6 +48,7 @@
     "@types/node-fetch": "^2.6.2",
     "@typescript-eslint/eslint-plugin": "5.59.11",
     "@typescript-eslint/parser": "5.59.11",
+    "@unpic/core": "workspace:^",
     "eslint": "8.42.0",
     "eslint-plugin-qwik": "^0.103.0",
     "node-fetch": "3.3.1",
@@ -60,8 +61,5 @@
   },
   "peerDependencies": {
     "@builder.io/qwik": "*"
-  },
-  "dependencies": {
-    "@unpic/core": "workspace:^"
   }
 }

--- a/packages/qwik/vite.config.ts
+++ b/packages/qwik/vite.config.ts
@@ -10,9 +10,6 @@ export default defineConfig(() => {
         formats: ["es", "cjs"],
         fileName: (format) => `index.qwik.${format === "es" ? "mjs" : "cjs"}`,
       },
-      rollupOptions: {
-        external: ["@unpic/core"],
-      },
     },
     plugins: [qwikVite()],
   };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -537,10 +537,6 @@ importers:
         version: 0.30.0(jsdom@21.1.1)
 
   packages/qwik:
-    dependencies:
-      '@unpic/core':
-        specifier: workspace:^
-        version: link:../core
     devDependencies:
       '@builder.io/qwik':
         specifier: 0.107.0
@@ -560,6 +556,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: 5.59.11
         version: 5.59.11(eslint@8.42.0)(typescript@5.0.4)
+      '@unpic/core':
+        specifier: workspace:^
+        version: link:../core
       eslint:
         specifier: 8.42.0
         version: 8.42.0


### PR DESCRIPTION
I'm not sure why, but when installed with pnpm rollup is unable to resolve the `@unpic/core` transitive dependency. This PR moves the package out of external deps, so that it is compiled into the bundle. Fixes #69