### PR TITLE
fix: always generate srcset if transformer is provided

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -295,11 +295,9 @@ export const getSrcSet = ({
   | undefined => {
   const canonical = getCanonicalCdnForUrl(src, cdn);
 
-  if (!canonical) {
-    return;
+  if (canonical && !transformer) {
+    transformer = getTransformer(canonical.cdn);
   }
-
-  transformer ||= getTransformer(canonical.cdn);
 
   if (!transformer) {
     return;
@@ -315,7 +313,7 @@ export const getSrcSet = ({
       // Not sure why TS isn't narrowing the type here
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const transformed = transformer!({
-        url: canonical.url,
+        url: canonical ? canonical.url : src,
         width: bp,
         height: transformedHeight,
       });


### PR DESCRIPTION
Currently if a canonical CDN can't be resolved then a srcset isn't generated. This PR changes the logic to still generate the srcset if a transformer function has been provided.

Fixes #275 