### PR TITLE
fix(lit): add css part pseudo-element

### DIFF
--- a/docs/src/content/img/lit.md
+++ b/docs/src/content/img/lit.md
@@ -31,3 +31,14 @@ You can then use the component in your HTML:
   alt="A lovely bath"
 ></unpic-img>
 ```
+
+## Styling
+
+If you need to style the `img` element, you can use the
+[`::part` pseudo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/::part):
+
+```css
+unpic-img::part(image) {
+  border-radius: 4px;
+}
+```

--- a/packages/lit/README.md
+++ b/packages/lit/README.md
@@ -45,4 +45,15 @@ You can then use the component in your HTML:
 ></unpic-img>
 ```
 
+## Styling
+
+If you need to style the `img` element, you can use the
+[`::part` pseudo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/::part):
+
+```css
+unpic-img::part(image) {
+  border-radius: 4px;
+}
+```
+
 For the supported props, see [the docs](https://unpic.pics/img/lit).

--- a/packages/lit/src/unpic-img.ts
+++ b/packages/lit/src/unpic-img.ts
@@ -61,6 +61,7 @@ export class UnpicImg
 
     return html`
       <img
+        part="image"
         src="${transformedProps.src}"
         alt="${transformedProps.alt}"
         width="${transformedProps.width}"


### PR DESCRIPTION
Unfortunately, it is currently not possible to apply custom styles to the Lit `unpic-img` web component. We need to use the [::part](https://developer.mozilla.org/en-US/docs/Web/CSS/::part) CSS pseudo-element to target specific elements within the shadow DOM. This pull request allows to apply styles to the `img` element, example:

```css
unpic-img::part(image) {
  border-radius: 8px;
}
```