### PR TITLE
fix(core): gracefully handle missing props

### DIFF
--- a/packages/core/test/core.test.tsx
+++ b/packages/core/test/core.test.tsx
@@ -1,34 +1,44 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, test, expect } from "vitest";
-import { transformProps } from '../src/core';
+import { transformProps } from "../src/core";
 
 describe("Core", () => {
   test("updates the src URL to include transformations", () => {
     const props = transformProps({
-      src: 'https://res.cloudinary.com/example/image/upload/images/my-image',
+      src: "https://res.cloudinary.com/example/image/upload/images/my-image",
       width: 800,
       height: 600,
-      layout: 'constrained',
-      objectFit: 'cover',
+      layout: "constrained",
+      objectFit: "cover",
     });
-    expect(props.src).toEqual('https://res.cloudinary.com/example/image/upload/w_800,h_600,c_lfill,f_auto/images/my-image');
+    expect(props.src).toEqual(
+      "https://res.cloudinary.com/example/image/upload/w_800,h_600,c_lfill,f_auto/images/my-image"
+    );
   });
 
   test("allows an image ID for src when using a custom transformer", () => {
-    const id = 'images/my-image';
+    const id = "images/my-image";
     const width = 800;
     const height = 800;
     const props = transformProps({
       src: id,
       width,
       height,
-      layout: 'constrained',
-      objectFit: 'cover',
+      layout: "constrained",
+      objectFit: "cover",
       transformer: ({ url: tUrl, width: tWidth, height: tHeight }) => {
-        return `https://res.cloudinary.com/example/image/upload/w_${tWidth},h_${tHeight},c_lfill,f_auto/${tUrl}`
-      }
+        return `https://res.cloudinary.com/example/image/upload/w_${tWidth},h_${tHeight},c_lfill,f_auto/${tUrl}`;
+      },
     });
-    expect(props.src).toEqual(`https://res.cloudinary.com/example/image/upload/w_${width},h_${height},c_lfill,f_auto/${id}`);
+    expect(props.src).toEqual(
+      `https://res.cloudinary.com/example/image/upload/w_${width},h_${height},c_lfill,f_auto/${id}`
+    );
+  });
+
+  test("doesn't throw if props are empty", () => {
+    const props = transformProps({} as any);
+    expect(props).toBeDefined();
+    expect(props.src).toBeUndefined();
+    expect(props.loading).toEqual("lazy");
   });
 });
-
-

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -83,5 +83,8 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
-  }
+  },
+  "exclude": [
+    "./dist/**/*",
+  ]
 }

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -83,5 +83,8 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
-  }
+  },
+  "exclude": [
+    "./dist/**/*",
+  ]
 }


### PR DESCRIPTION
Currently `transformProps` throws if there is a missing url. This PR handles it more gracefully. It also prevents logs in production by using a log wrapper.