### PR TITLE
fix(angular): remove debug logs

### DIFF
--- a/packages/angular/src/lib/unpic-image.directive.ts
+++ b/packages/angular/src/lib/unpic-image.directive.ts
@@ -66,7 +66,6 @@ export class UnpicImageDirective implements OnChanges {
     }
 
     for (const prop in props) {
-      console.log('img', prop);
       if (Object.prototype.hasOwnProperty.call(props, prop)) {
         const propValue = props[prop as keyof typeof props];
         if (propValue === undefined) {

--- a/packages/angular/src/lib/unpic-source.directive.ts
+++ b/packages/angular/src/lib/unpic-source.directive.ts
@@ -58,7 +58,6 @@ export class UnpicSourceDirective implements OnChanges {
     } as Props);
 
     for (const prop in props) {
-      console.log('source', prop);
       if (Object.prototype.hasOwnProperty.call(props, prop)) {
         const propValue = props[prop as keyof typeof props];
         if (propValue === undefined) {


### PR DESCRIPTION
I have been trying this component in an Angular app, and I noticed a lot of console messages like

```
img src
img decode
img srcset
(etc...)
```

It was a little distracting and hard to find the source of the logs because the console.log in my build was wrapped by some other code, so the stack trace was obscured. I imagine the logs help with development of this component but maybe not needed in the distributed code. May I suggest one of the following changes to the Angular component?

1. Remove the logs
2. Add an opt-in debug log mode
3. Keep the logs but prefix with `unpic` or some other unique label so it's easy to identify the source

I am submitting this PR with approach 1 just because that is the simplest to prepare for me.