### PR TITLE
[Svelte] Forward load listener on Svelte Component

### DIFF
--- a/packages/svelte/src/lib/image.svelte
+++ b/packages/svelte/src/lib/image.svelte
@@ -24,4 +24,4 @@
     .join(";");
 </script>
 
-<img {alt} {style} {...transformedProps} />
+<img {alt} {style} {...transformedProps} on:load />


### PR DESCRIPTION
## Description of the Problem

This package is great! We are using it in our Sveltekit app. One problem we have run into though is that due to Sveltekit's heavily reliance on Client Side rendering we can run into some weird situations where it shows the old image for a little bit when navigating to a new page.

## Description of the Fix

I think it is a bit out of the scope of this package to handle all of this for us, but I think adding the load event for the image will at least give us the ability to fix it on our side by listening for when we get the image. That way when src changes we could set style opacity 0 and then set to 1 on load. 