### PR TITLE
fix(core): add styles to images without transformers

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ including:
 - Directus
 - Imgix, including Unsplash, DatoCMS, Sanity and Prismic
 - Kontent.ai
+- Netlify
 - Shopify
 - Storyblok
 - Vercel / Next.js

--- a/docs/src/content/img/react.mdx
+++ b/docs/src/content/img/react.mdx
@@ -76,8 +76,8 @@ import logo from "../public/logo.png";
 />
 ```
 
-> **:warning: For versions of Next.js before 14.0.0, import from
-> `@unpic/react/next-legacy`, not `@unpic/react/nextjs`**
+> ⚠️ For versions of Next.js before 14.0.0, import from
+> `@unpic/react/next-legacy`, not `@unpic/react/nextjs`
 
 ### Differences from `next/image`
 

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -518,15 +518,14 @@ export function transformProps<
     UnpicImageProps<TImageAttributes, TStyle>,
     "width" | "height" | "aspectRatio" | "layout" | "objectFit" | "background"
   >;
-
+  transformedProps.sizes ||= getSizes(width, layout);
+  if (!unstyled) {
+    transformedProps.style = {
+      ...getStyle<TImageAttributes, TStyle>(styleProps),
+      ...transformedProps.style,
+    };
+  }
   if (transformer) {
-    transformedProps.sizes ||= getSizes(width, layout);
-    if (!unstyled) {
-      transformedProps.style = {
-        ...getStyle<TImageAttributes, TStyle>(styleProps),
-        ...transformedProps.style,
-      };
-    }
     transformedProps.srcset = getSrcSet({
       src: url,
       width,

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -78,8 +78,8 @@ import logo from "../public/logo.png";
 </>;
 ```
 
-> **:warning: For versions of Next.js before 14.0.0, import from
-> `@unpic/react/next-legacy`, not `@unpic/react/nextjs`**
+> ⚠️ For versions of Next.js before 14.0.0, import from
+> `@unpic/react/next-legacy`, not `@unpic/react/nextjs`
 
 ### Differences from `next/image`
 


### PR DESCRIPTION
Currently if an image does not match a CDN we don't apply any styles. This is unexpected. This PR ensures we apply styles in all cases.

Fixes #360