### PR TITLE
fix(svelte): pin style-object-to-css-string

### DIFF
--- a/examples/webc/package.json
+++ b/examples/webc/package.json
@@ -14,6 +14,6 @@
     "@11ty/eleventy-plugin-webc": "^0.11.1",
     "@unpic/core": "workspace:^",
     "@unpic/webc": "workspace:^",
-    "style-object-to-css-string": "^1.0.1"
+    "style-object-to-css-string": "1.0.1"
   }
 }

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -34,7 +34,7 @@
   "type": "module",
   "dependencies": {
     "@unpic/core": "workspace:^",
-    "style-object-to-css-string": "^1.0.1",
+    "style-object-to-css-string": "1.0.1",
     "unpic": "^3.14.1"
   },
   "peerDependencies": {

--- a/packages/webc/package.json
+++ b/packages/webc/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://unpic.pics/img/webc",
   "dependencies": {
     "@unpic/core": "workspace:^",
-    "style-object-to-css-string": "^1.0.1"
+    "style-object-to-css-string": "1.0.1"
   },
   "devDependencies": {
     "@11ty/webc": "^0.11.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -484,7 +484,7 @@ importers:
         specifier: workspace:^
         version: link:../../packages/webc
       style-object-to-css-string:
-        specifier: ^1.0.1
+        specifier: 1.0.1
         version: 1.0.1
 
   packages/angular:
@@ -731,7 +731,7 @@ importers:
         specifier: workspace:^
         version: link:../core
       style-object-to-css-string:
-        specifier: ^1.0.1
+        specifier: 1.0.1
         version: 1.0.1
       unpic:
         specifier: ^3.14.1
@@ -808,7 +808,7 @@ importers:
         specifier: workspace:^
         version: link:../core
       style-object-to-css-string:
-        specifier: ^1.0.1
+        specifier: 1.0.1
         version: 1.0.1
     devDependencies:
       '@11ty/webc':


### PR DESCRIPTION
Pins the dependency because of https://github.com/Tbhesswebber/style-object-to-css-string/issues/27 
Fixes #392 