### PR TITLE
fix: Add 'fetchpriority' to fixedMap in camelize.ts

### DIFF
--- a/packages/react/src/camelize.ts
+++ b/packages/react/src/camelize.ts
@@ -2,6 +2,7 @@ import type { HTMLAttributes } from "react";
 const nestedKeys = new Set(["style"]);
 const fixedMap: Record<string, string> = {
   srcset: "srcSet",
+  fetchpriority: "fetchPriority"
 };
 const camelize = (key: string) => {
   if (key.startsWith("data-") || key.startsWith("aria-")) {


### PR DESCRIPTION
When using the `priority` prop with @unpic/react I would get the following console error: 
```
Warning: Invalid DOM property `fetchpriority`. Did you mean `fetchPriority`?
```

Looking at the DOM confirms that the property is being added without any capitalization as 'fetchpriority'. I assumed adding it to `fixedMap` was the right approach (and tested locally to confirm the correct property is used) but happy to just create an issue if you'd rather solve another way!