### PR TITLE
fix(vue): add transform to props list

### DIFF
--- a/packages/vue/src/image.vue
+++ b/packages/vue/src/image.vue
@@ -4,6 +4,7 @@
 
 <script setup lang="ts">
 import { transformProps, UnpicImageProps } from "@unpic/core";
+import { UrlTransformer } from "unpic";
 import { ImgHTMLAttributes, computed, useAttrs } from "vue";
 
 export interface Props extends /* @vue-ignore */ ImgHTMLAttributes {
@@ -17,6 +18,7 @@ export interface Props extends /* @vue-ignore */ ImgHTMLAttributes {
   aspectRatio?: number;
   objectFit?: "contain" | "cover" | "fill" | "none" | "scale-down" | "inherit" | "initial";
   unstyled?: boolean;
+  transformer?: UrlTransformer;
 }
 
 const props = defineProps<Props>();


### PR DESCRIPTION
Hello :wave: 

This PR fix #436 and fix https://github.com/nuxt-modules/cloudinary/issues/181 . 

When using `useAttrs()`, it doesn't disable attribute inheritance in a vue component. Since `transformer` isn't declared as a prop, vue will try to render it as an attribute.

It doesn't matter server-side thanks to vue/server-renderer which clean the html. However there's no cleaning client-side so vue will render `transformer` as an attribute.