### PR TITLE
chore(docs): update the list of supported CDNs

### DIFF
--- a/docs/src/content/docs/lib/index.md
+++ b/docs/src/content/docs/lib/index.md
@@ -108,6 +108,11 @@ is not auto-detected.
 - Storyblok
 - Vercel / Next.js
 - WordPress.com and Jetpack Site Accelerator
+- ImageEngine
+- ImageKit.io
+- Cloudimage
+- Uploadcare
+- Supabase
 
 ## Delegated URLs
 


### PR DESCRIPTION
Updated the list of supported CDNs [in the docs](https://unpic.pics/lib/). Added:

```diff
+ ImageEngine
+ ImageKit.io
+ Cloudimage
+ Uploadcare
+ Supabase
```