### PR TITLE
fix(react): handle fetchpriority vs fetchPriority

### DIFF
--- a/packages/react/src/camelize.ts
+++ b/packages/react/src/camelize.ts
@@ -1,9 +1,15 @@
 import type { HTMLAttributes } from "react";
+import * as React from "react";
+
 const nestedKeys = new Set(["style"]);
+
+export const isNewReact = "use" in React;
+
 const fixedMap: Record<string, string> = {
   srcset: "srcSet",
-  fetchpriority: "fetchPriority"
+  fetchpriority: isNewReact ? "fetchPriority" : "fetchpriority",
 };
+
 const camelize = (key: string) => {
   if (key.startsWith("data-") || key.startsWith("aria-")) {
     return key;
@@ -14,12 +20,12 @@ const camelize = (key: string) => {
 };
 
 export function camelizeProps<TObject extends HTMLAttributes<HTMLElement>>(
-  props: TObject
+  props: TObject,
 ): TObject {
   return Object.fromEntries(
     Object.entries(props).map(([k, v]) => [
       camelize(k),
       nestedKeys.has(k) && v && typeof v !== "string" ? camelizeProps(v) : v,
-    ])
+    ]),
   ) as TObject;
 }


### PR DESCRIPTION
When https://github.com/facebook/react/pull/25927 was merged it meant that React would accept `fetchPriority` as a prop. Unfortunately it then wouldn't accept `fetchpriority` anymore. This would lead to scary error messages in dev or SSR. In Next.js there's no way to know which version you're using, because Next.js reports both versions as 18.x, even when actually using the bundled experimental version that includes this change. The upshot is that in Next.js, pages router needs `fetchpriority` and app router needs `fetchPriority`. The best way to detect which one you're using is to look for the existence of `use()`. React I love you but you're bringing me down.

Fixes #425 