### PR TITLE
feat: add Eleventy shortcode

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        site: [astro, lit, preact, qwik, react, solid, webc]
+        site: [astro, lit, preact, qwik, react, solid, webc, 11ty]
     steps:
       - run: echo Running tests in ${{ matrix.site }}
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@
 [<img src="https://raw.githubusercontent.com/gilbarbara/logos/main/logos/angular-icon.svg" height="16" alt="angular" /> Angular](https://unpic.pics/img/angular)
 •
 [<img src="https://raw.githubusercontent.com/gilbarbara/logos/main/logos/lit-icon.svg" height="16" alt="lit" /> Lit](https://unpic.pics/img/lit)
+•
+[<img src="https://raw.githubusercontent.com/gilbarbara/logos/main/logos/eleventy.svg" height="16" alt="11ty" /> Eleventy](https://unpic.pics/img/11ty)
 
 </h3>
 

--- a/docs/src/content/img/11ty.md
+++ b/docs/src/content/img/11ty.md
@@ -1,0 +1,38 @@
+---
+title: "@unpic/11ty"
+description: "Eleventy shortcode for responsive images using the unpic-img library"
+---
+
+# @unpic/11ty
+
+The `@unpic/11ty` package provides an Eleventy shortcode, `unpic`, for embedding responsive images using the unpic-img library. This shortcode simplifies the process of including optimized images in your Eleventy projects, ensuring they follow best practices for responsive design and performance.
+
+## Installation
+
+To install the `@unpic/11ty` package in your Eleventy project, run:
+
+```bash
+npm install @unpic/11ty
+```
+
+## Usage
+
+After installation, add the shortcode to your Eleventy configuration:
+
+```js
+const unpic = require('@unpic/11ty');
+
+module.exports = function(eleventyConfig) {
+  eleventyConfig.addShortcode('unpic', unpic);
+};
+```
+
+You can then use the `unpic` shortcode in your Eleventy templates to embed responsive images. Here's an example:
+
+```njk
+{% unpic src="https://example.com/image.jpg", alt="A description of the image", width="600", height="400" %}
+```
+
+This shortcode will generate an `<img>` tag with the appropriate `srcset` and `sizes` attributes for responsive images, following best practices for performance and accessibility.
+
+For more detailed usage instructions and examples, refer to the documentation for the `@unpic/webc` package, as the shortcode provided by `@unpic/11ty` is designed to offer similar functionality within Eleventy projects.

--- a/examples/11ty/.eleventy.js
+++ b/examples/11ty/.eleventy.js
@@ -1,0 +1,11 @@
+const { EleventyServerlessBundlerPlugin } = require("@11ty/eleventy");
+const unpicShortcode = require("@unpic/11ty");
+
+module.exports = function(eleventyConfig) {
+  eleventyConfig.addPlugin(EleventyServerlessBundlerPlugin, {
+    name: "unpic",
+    functionsDir: "./netlify/functions/",
+  });
+
+  eleventyConfig.addShortcode("unpic", unpicShortcode);
+};

--- a/examples/11ty/index.md
+++ b/examples/11ty/index.md
@@ -1,0 +1,13 @@
+---
+title: Unpic 11ty Demo
+layout: base.njk
+---
+
+<h1>Unpic 11ty Demo</h1>
+
+<p>This is a demo page showcasing the Unpic 11ty shortcode for embedding responsive images.</p>
+
+<h2>Responsive Image Example</h2>
+{% unpic src="https://images.unsplash.com/photo-1617718295766-0f839c2853e7", alt="A beautiful landscape", width="600", height="400" %}
+{% unpic src="https://cdn.shopify.com/static/sample-images/garnished.jpeg", alt="A delicious dish", width="800", height="600" %}
+{% unpic src="https://bunnyoptimizerdemo.b-cdn.net/bunny7.jpg", alt="A cute bunny", width="800", height="600" %}

--- a/examples/11ty/package.json
+++ b/examples/11ty/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "unpic-11ty-example",
+  "version": "1.0.0",
+  "description": "An example Eleventy project using the @unpic/11ty shortcode for responsive images.",
+  "scripts": {
+    "build": "eleventy",
+    "serve": "eleventy --serve"
+  },
+  "dependencies": {
+    "@11ty/eleventy": "^1.0.0",
+    "@unpic/11ty": "^1.0.0"
+  }
+}

--- a/examples/11ty/src/index.njk
+++ b/examples/11ty/src/index.njk
@@ -1,0 +1,12 @@
+---
+layout: layout.njk
+---
+
+<h1>Unpic 11ty Demo</h1>
+
+<p>This is a demo page showcasing the Unpic 11ty shortcode for embedding responsive images.</p>
+
+<h2>Responsive Image Example</h2>
+{% unpic src="https://images.unsplash.com/photo-1617718295766-0f839c2853e7", alt="A beautiful landscape", width="600", height="400" %}
+{% unpic src="https://cdn.shopify.com/static/sample-images/garnished.jpeg", alt="A delicious dish", width="800", height="600" %}
+{% unpic src="https://bunnyoptimizerdemo.b-cdn.net/bunny7.jpg", alt="A cute bunny", width="800", height="600" %}

--- a/packages/11ty/README.md
+++ b/packages/11ty/README.md
@@ -1,0 +1,23 @@
+# @unpic/11ty
+
+This package provides an Eleventy shortcode for embedding responsive images using the unpic-img library, making it easier to include optimized images in your Eleventy projects.
+
+## Installation
+
+To use the `@unpic/11ty` package in your Eleventy project, install it via npm:
+
+```bash
+npm install @unpic/11ty
+```
+
+## Usage
+
+After installation, you can use the `unpic` shortcode in your Eleventy templates to embed responsive images. Here's an example:
+
+```njk
+{% unpic src="https://example.com/image.jpg", alt="A description of the image", width="600", height="400" %}
+```
+
+This shortcode will generate an `<img>` tag with the appropriate `srcset` and `sizes` attributes for responsive images, following best practices for performance and accessibility.
+
+For more detailed usage instructions and examples, refer to the documentation for the `@unpic/webc` package, as the shortcode provided by `@unpic/11ty` is designed to offer similar functionality within Eleventy projects.

--- a/packages/11ty/index.js
+++ b/packages/11ty/index.js
@@ -1,0 +1,11 @@
+const { transformProps } = require("@unpic/core");
+
+module.exports = function(eleventyConfig) {
+  eleventyConfig.addShortcode("unpic", function(props) {
+    const transformedProps = transformProps(props);
+    const attributes = Object.entries(transformedProps)
+      .map(([key, value]) => `${key}="${value}"`)
+      .join(" ");
+    return `<img ${attributes}>`;
+  });
+};

--- a/packages/11ty/package.json
+++ b/packages/11ty/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@unpic/11ty",
+  "version": "1.0.0",
+  "description": "Eleventy shortcode for embedding responsive images using the unpic-img library.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@unpic/core": "^0.0.49",
+    "@11ty/eleventy": "^1.0.0"
+  }
+}


### PR DESCRIPTION
Related to #624

Introduces the `@unpic/11ty` package, providing an Eleventy shortcode for embedding responsive images using the unpic-img library.

- **Package Creation**: Adds a new package `@unpic/11ty` with dependencies on `@unpic/core` and `@11ty/eleventy`. Includes a `package.json` and a main `index.js` file implementing the `unpic` shortcode.
- **Shortcode Implementation**: Implements the `unpic` Eleventy shortcode in `index.js`, utilizing `@unpic/core` to transform image properties and generate an `<img>` tag with responsive attributes.
- **Documentation and Examples**: Adds a `README.md` in the `@unpic/11ty` package detailing installation and usage instructions. Also, updates the main `README.md` to include Eleventy in the list of supported frameworks.
- **Demo and Testing**: Includes an Eleventy demo site in `examples/11ty` demonstrating the use of the `unpic` shortcode. Modifies the `.github/workflows/e2e.yml` to add Eleventy to the end-to-end tests.
- **Documentation Update**: Updates the documentation site with a new page `docs/src/content/img/11ty.md` explaining how to use the `@unpic/11ty` package in Eleventy projects.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ascorbic/unpic-img/issues/624?shareId=31f24de6-2e56-4c3b-8f0b-c9257e71cdc6).