### PR TITLE
fix: add default export

### DIFF
--- a/.changeset/cuddly-balloons-hug.md
+++ b/.changeset/cuddly-balloons-hug.md
@@ -1,0 +1,5 @@
+---
+"@unpic/svelte": patch
+---
+
+Adds default export

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -53,6 +53,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "default": "./dist/index.js",
       "types": "./dist/index.d.ts",
       "svelte": "./dist/index.js"
     },


### PR DESCRIPTION
The `svelte` field is a [legacy field](https://svelte.dev/docs/kit/packaging#Anatomy-of-a-package.json-svelte). With the latest version of vite and vitest, it didn't recognize the export when it was just `svelte`. Adding the default export got it to be recognized.

The error before this was this:
```
Error: Failed to resolve entry for package "svelte-media-queries". The package may have incorrect main/module/exports specified in its package.json: No known conditions for "." specifier in "@unpic/svelte" package
```