### PR TITLE
ci: install Netlify CLI in gh actions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,6 +29,8 @@ jobs:
         run: |
           corepack enable
           pnpm install
+      - name: Install Netlify CLI
+        run: pnpm install -g netlify-cli
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
       - name: Run tests


### PR DESCRIPTION
GH Actions runners have been [upgraded to 2404](https://github.com/actions/runner-images/issues/10636), which no longer include the Netlify CLI. We're using this for e2e tests, so this PR manually installs it.