### PR TITLE
ci: update GitHub Actions to use Node.js LTS

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: latest
+          node-version: 'lts/*'
           cache: "pnpm"
           check-latest: true
           registry-url: "https://registry.npmjs.org"
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: latest
+          node-version: 'lts/*'
       - name: Download blob reports from GitHub Actions Artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -33,7 +33,7 @@ jobs:
           cache: "pnpm"
           check-latest: true
           registry-url: "https://registry.npmjs.org"
-          node-version: latest
+          node-version: 'lts/*'
       - name: Install dependencies
         run: pnpm install
       - name: Format

--- a/.github/workflows/pkg-pr.yml
+++ b/.github/workflows/pkg-pr.yml
@@ -30,7 +30,7 @@ jobs:
         uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 'lts/*'
           cache: "pnpm"
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: latest
+          node-version: 'lts/*'
           cache: "pnpm"
 
       - name: Install Dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           cache: "pnpm"
           check-latest: true
           registry-url: "https://registry.npmjs.org"
-          node-version: latest
+          node-version: 'lts/*'
       - name: Install dependencies
         run: pnpm install
       - name: Build


### PR DESCRIPTION
## Summary
- Updated all GitHub Actions workflows to use `'lts/*'` instead of `'latest'` or specific Node.js versions
- Affects 5 workflow files: e2e.yml, format.yml, pkg-pr.yml, release.yml, and test.yml
- Ensures consistent, stable Node.js versions across CI/CD pipelines

## Test plan
- [x] Verify all workflow files are updated correctly
- [ ] Monitor CI/CD runs to ensure workflows continue to work with LTS Node.js
- [ ] Check that all tests pass with the LTS version

🤖 Generated with [Claude Code](https://claude.ai/code)