### PR TITLE
fix(astro): Use correct `endpoint` option

### DIFF
--- a/.changeset/smart-jokes-serve.md
+++ b/.changeset/smart-jokes-serve.md
@@ -2,4 +2,4 @@
 "@unpic/astro": patch
 ---
 
-If you're using `trailingSlash: 'always'` and images inside MDX those images might not display during `astro dev`. They should now show correctly.
+Fixes a bug that caused images in MDX files to sometimes not display when using`trailingSlash: 'always'`. 

--- a/.changeset/smart-jokes-serve.md
+++ b/.changeset/smart-jokes-serve.md
@@ -1,0 +1,5 @@
+---
+"@unpic/astro": patch
+---
+
+If you're using `trailingSlash: 'always'` and images inside MDX those images might not display during `astro dev`. They should now show correctly.

--- a/packages/astro/src/service/base.ts
+++ b/packages/astro/src/service/base.ts
@@ -97,11 +97,8 @@ const service: ExternalImageService<UnpicConfig> = {
       options,
       imageConfig.service.config,
     );
-    transformOptions.cdnOptions = getEndpointOptions(
-      imageConfig,
-      transformOptions.cdnOptions,
-    );
-    return transformUrl(transformOptions)?.toString() ?? "";
+    const providerOptions = getEndpointOptions(imageConfig);
+    return transformUrl(transformOptions, {}, providerOptions)?.toString() ?? "";
   },
   getHTMLAttributes(options: ImageTransform, imageConfig) {
     const transformOptions = getTransformOptions(

--- a/packages/astro/test/astro.test.ts
+++ b/packages/astro/test/astro.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from "vitest";
 import { Image } from "../index.js";
 import PictureTestWrapper from "./PictureTestWrapper.astro";
+import baseImageService from "../src/service/base.js"
 import { render } from "./astro-testing-library.js";
 import {
   expectImagePropsToMatchTransformed,
@@ -31,3 +32,30 @@ describe("the Astro component", () => {
     });
   }
 });
+
+describe("the Astro image service", () => {
+  describe('base', () => {
+    test('respects trailingSlash: always', async () => {
+      const url = await baseImageService.getURL({
+        src: {
+          src: '/@fs/path/to/image.jpg',
+          width: 800,
+          height: 800,
+          format: 'jpg',
+        }
+      }, {
+        endpoint: {
+          route: '/_image/'
+        },
+        service: {
+          entrypoint: '/path/to/service/base.ts',
+          config: {}
+        },
+        domains: [],
+        remotePatterns: []
+      })
+
+      expect(url).toContain('/_image/')
+    })
+  })
+})


### PR DESCRIPTION
Hey Matt 👋 

I've looked into https://github.com/ascorbic/unpic-img/issues/771 again as my images used in MDX pages were still broken during development ([example usage](https://github.com/LekoArts/portfolio-v3/blob/4ee1d92bc14193335df2db714a61f786dcf20535/src/pages/about.mdx#L11)).

I've looked at https://github.com/ascorbic/unpic/blob/5989f6334a751ba4ad5ace4804455a641f3b840c/src/transform.ts#L106-L109 and noticed that for Astro's usage of `transformUrl()` only the first parameter is passed. I assume the old usage is from this breaking change: https://github.com/ascorbic/unpic/blob/5989f6334a751ba4ad5ace4804455a641f3b840c/UPGRADING.md#L16-L41

So `transformOptions.cdnOptions` doesn't do anything anymore. By passing the `providerOptions` as third arg to `transformUrl()` the image used the correct `/_image/` endpoint.

Fixes https://github.com/ascorbic/unpic-img/issues/771