### PR TITLE
fix: allow objectFit prop to accept null to disable inline style

### DIFF
--- a/.changeset/fix-objectfit-null.md
+++ b/.changeset/fix-objectfit-null.md
@@ -1,0 +1,5 @@
+---
+"@unpic/core": patch
+---
+
+Allow `objectFit` prop to accept `null` to disable inline object-fit style, enabling CSS classes to control the property

--- a/packages/core/src/base.ts
+++ b/packages/core/src/base.ts
@@ -63,7 +63,7 @@ export const getStyle = <
   "width" | "height" | "aspectRatio" | "layout" | "objectFit" | "background"
 >): TImageAttributes["style"] => {
   const styleEntries: Array<[prop: string, value: string | undefined]> = [
-    ["object-fit", objectFit],
+    ["object-fit", objectFit ?? undefined],
   ];
 
   // If background is a URL, set it to cover the image and not repeat

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -197,6 +197,7 @@ export type Layout = "fixed" | "constrained" | "fullWidth";
 
 /**
  * Object-fit options for controlling how the image fills its container.
+ * Pass `null` to disable inline object-fit style and allow CSS to control it.
  */
 export type ObjectFit =
   | "contain"
@@ -205,4 +206,5 @@ export type ObjectFit =
   | "none"
   | "scale-down"
   | "inherit"
-  | "initial";
+  | "initial"
+  | null;

--- a/packages/core/test/core.test.tsx
+++ b/packages/core/test/core.test.tsx
@@ -50,4 +50,42 @@ describe("Core", () => {
     expect(props.width).toEqual(100);
     expect(props.height).toEqual(200);
   });
+
+  test("objectFit defaults to cover", () => {
+    const props = transformProps({
+      src: "https://res.cloudinary.com/example/image/upload/images/my-image",
+      width: 800,
+      height: 600,
+      layout: "constrained",
+    });
+    expect((props.style as Record<string, string>)["object-fit"]).toEqual(
+      "cover",
+    );
+  });
+
+  test("objectFit can be set to contain", () => {
+    const props = transformProps({
+      src: "https://res.cloudinary.com/example/image/upload/images/my-image",
+      width: 800,
+      height: 600,
+      layout: "constrained",
+      objectFit: "contain",
+    });
+    expect((props.style as Record<string, string>)["object-fit"]).toEqual(
+      "contain",
+    );
+  });
+
+  test("objectFit null disables inline object-fit style", () => {
+    const props = transformProps({
+      src: "https://res.cloudinary.com/example/image/upload/images/my-image",
+      width: 800,
+      height: 600,
+      layout: "constrained",
+      objectFit: null,
+    });
+    expect(
+      (props.style as Record<string, string>)["object-fit"],
+    ).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #283

This PR allows users to pass `objectFit={null}` to disable the inline `object-fit` style, enabling CSS classes to control the property instead.

## Problem

The `objectFit` prop defaults to `"cover"` and is applied as an inline style, which has higher specificity than CSS classes. This prevents users from overriding `object-fit` via CSS-in-JS libraries or CSS modules.

## Solution

- Extended the `ObjectFit` type to accept `null` as a valid value
- When `objectFit={null}` is passed, the inline `object-fit` style is not applied
- This allows CSS classes to control the `object-fit` property
- Default behavior remains unchanged (`cover` is still the default)

## Usage

```tsx
// Before: CSS class gets overridden by inline style
<Image
  src={props.img.src}
  layout="fullWidth"
  class={style({ objectFit: "contain" })} // Gets overridden!
/>

// After: Pass objectFit={null} to let CSS control it
<Image
  src={props.img.src}
  layout="fullWidth"
  objectFit={null}
  class={style({ objectFit: "contain" })} // Works!
/>

// Or use the prop directly
<Image
  src={props.img.src}
  layout="fullWidth"
  objectFit="contain"
/>
```

## Testing

- Added tests to verify:
  - Default `objectFit` is `cover`
  - `objectFit="contain"` works as expected
  - `objectFit={null}` removes inline style