### PR TITLE
fix!: remove default object-fit inline style to allow CSS override

### DIFF
--- a/.changeset/fix-objectfit-css-override.md
+++ b/.changeset/fix-objectfit-css-override.md
@@ -1,0 +1,7 @@
+---
+"@unpic/core": major
+---
+
+Remove default `object-fit: cover` inline style to allow CSS classes to control the property
+
+BREAKING CHANGE: Images no longer have `object-fit: cover` applied by default. If you need this behavior, explicitly pass `objectFit="cover"` to your Image components.

--- a/packages/core/src/base.ts
+++ b/packages/core/src/base.ts
@@ -56,7 +56,7 @@ export const getStyle = <
   height,
   aspectRatio,
   layout,
-  objectFit = "cover",
+  objectFit,
   background,
 }: Pick<
   UnpicBaseImageProps<TOperations, TOptions, TImageAttributes, TStyle>,

--- a/packages/core/test/core.test.tsx
+++ b/packages/core/test/core.test.tsx
@@ -50,4 +50,42 @@ describe("Core", () => {
     expect(props.width).toEqual(100);
     expect(props.height).toEqual(200);
   });
+
+  test("does not apply object-fit by default", () => {
+    const props = transformProps({
+      src: "https://res.cloudinary.com/example/image/upload/images/my-image",
+      width: 800,
+      height: 600,
+      layout: "constrained",
+    });
+    expect(
+      (props.style as Record<string, string>)["object-fit"],
+    ).toBeUndefined();
+  });
+
+  test("applies object-fit when explicitly set", () => {
+    const props = transformProps({
+      src: "https://res.cloudinary.com/example/image/upload/images/my-image",
+      width: 800,
+      height: 600,
+      layout: "constrained",
+      objectFit: "cover",
+    });
+    expect((props.style as Record<string, string>)["object-fit"]).toEqual(
+      "cover",
+    );
+  });
+
+  test("applies object-fit contain when set", () => {
+    const props = transformProps({
+      src: "https://res.cloudinary.com/example/image/upload/images/my-image",
+      width: 800,
+      height: 600,
+      layout: "constrained",
+      objectFit: "contain",
+    });
+    expect((props.style as Record<string, string>)["object-fit"]).toEqual(
+      "contain",
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #283

This PR removes the default `object-fit: cover` inline style so that CSS classes can control the property without being overridden.

## Problem

The `objectFit` prop defaulted to `"cover"` and was applied as an inline style. Since inline styles have higher specificity than CSS classes, users couldn't override `object-fit` via CSS-in-JS libraries or CSS modules - the inline style would always win.

```tsx
// Before: This doesn't work - inline style overrides the class
<Image
  src={props.img.src}
  layout="fullWidth"
  class={style({ objectFit: "contain" })}
/>
```

## Solution

Remove the default `object-fit: cover` inline style. Now:
- CSS classes work as expected
- Users who want `cover` can explicitly pass `objectFit="cover"`
- The browser's default `object-fit: fill` applies when neither is set

```tsx
// After: CSS classes work!
<Image
  src={props.img.src}
  layout="fullWidth"
  class={style({ objectFit: "contain" })}
/>

// Or use the prop directly
<Image
  src={props.img.src}
  layout="fullWidth"
  objectFit="cover"
/>
```

## Breaking Change

This is a **breaking change**. Images that relied on the implicit `object-fit: cover` default will need to either:
1. Add `objectFit="cover"` explicitly, or
2. Set it via CSS

## Testing

Added tests to verify:
- No `object-fit` is applied by default
- `objectFit="cover"` works when explicitly set
- `objectFit="contain"` works when explicitly set