### PR TITLE
fix: only apply default object-fit when no CSS class is provided

### DIFF
--- a/.changeset/fix-objectfit-css-override.md
+++ b/.changeset/fix-objectfit-css-override.md
@@ -1,0 +1,5 @@
+---
+"@unpic/core": patch
+---
+
+Only apply default `object-fit: cover` when no CSS class is provided, allowing CSS classes to control the property

--- a/packages/core/src/base.ts
+++ b/packages/core/src/base.ts
@@ -56,7 +56,7 @@ export const getStyle = <
   height,
   aspectRatio,
   layout,
-  objectFit = "cover",
+  objectFit,
   background,
 }: Pick<
   UnpicBaseImageProps<TOperations, TOptions, TImageAttributes, TStyle>,
@@ -324,6 +324,15 @@ export function transformBaseImageProps<
     options,
     ...transformedProps
   } = transformSharedProps(props);
+
+  // Default to object-fit: cover only if no class is provided
+  // This allows CSS classes to control object-fit without being overridden
+  const hasClass =
+    "class" in transformedProps || "className" in transformedProps;
+  if (objectFit === undefined && !hasClass) {
+    objectFit = "cover";
+  }
+
   // Auto-generate a low-res image for blurred placeholders
   if (transformer && background === "auto") {
     const lowResHeight = aspectRatio

--- a/packages/core/test/core.test.tsx
+++ b/packages/core/test/core.test.tsx
@@ -50,4 +50,56 @@ describe("Core", () => {
     expect(props.width).toEqual(100);
     expect(props.height).toEqual(200);
   });
+
+  test("defaults to object-fit: cover when no class is provided", () => {
+    const props = transformProps({
+      src: "https://res.cloudinary.com/example/image/upload/images/my-image",
+      width: 800,
+      height: 600,
+      layout: "constrained",
+    });
+    expect((props.style as Record<string, string>)["object-fit"]).toEqual(
+      "cover",
+    );
+  });
+
+  test("does not apply object-fit when class is provided", () => {
+    const props = transformProps({
+      src: "https://res.cloudinary.com/example/image/upload/images/my-image",
+      width: 800,
+      height: 600,
+      layout: "constrained",
+      class: "my-custom-class",
+    } as any);
+    expect(
+      (props.style as Record<string, string>)["object-fit"],
+    ).toBeUndefined();
+  });
+
+  test("does not apply object-fit when className is provided", () => {
+    const props = transformProps({
+      src: "https://res.cloudinary.com/example/image/upload/images/my-image",
+      width: 800,
+      height: 600,
+      layout: "constrained",
+      className: "my-custom-class",
+    } as any);
+    expect(
+      (props.style as Record<string, string>)["object-fit"],
+    ).toBeUndefined();
+  });
+
+  test("applies explicit objectFit even when class is provided", () => {
+    const props = transformProps({
+      src: "https://res.cloudinary.com/example/image/upload/images/my-image",
+      width: 800,
+      height: 600,
+      layout: "constrained",
+      class: "my-custom-class",
+      objectFit: "contain",
+    } as any);
+    expect((props.style as Record<string, string>)["object-fit"]).toEqual(
+      "contain",
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #283

This PR makes CSS classes work for `object-fit` without any extra props needed.

## Problem

The `objectFit` prop defaulted to `"cover"` and was applied as an inline style. Since inline styles have higher specificity than CSS classes, users couldn't override `object-fit` via CSS-in-JS libraries or CSS modules.

```tsx
// Before: Doesn't work - inline style overrides the class
<Image
  src={props.img.src}
  layout="fullWidth"
  class={style({ objectFit: "contain" })}
/>
```

## Solution

Only apply the default `object-fit: cover` when no `class` or `className` prop is provided. This way:

| Scenario | Behavior |
|----------|----------|
| No class, no objectFit | `object-fit: cover` (backward compatible) |
| With class, no objectFit | No inline object-fit (CSS controls it) |
| Explicit objectFit prop | Always applied (regardless of class) |

```tsx
// After: Just works!
<Image
  src={props.img.src}
  layout="fullWidth"
  class={style({ objectFit: "contain" })}
/>
```

## Not a Breaking Change

Existing code without classes continues to work exactly as before. Only users who pass classes AND want CSS to control object-fit benefit from this change.

## Testing

Added tests to verify:
- Default `object-fit: cover` when no class
- No `object-fit` when `class` is provided  
- No `object-fit` when `className` is provided
- Explicit `objectFit` prop works even with class