### PR TITLE
feat(astro): add Astro 6 support

### DIFF
--- a/.changeset/serious-rats-fold.md
+++ b/.changeset/serious-rats-fold.md
@@ -1,0 +1,5 @@
+---
+"@unpic/astro": patch
+---
+
+feat(astro): add Astro 6 support

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -43,7 +43,7 @@
     "@astrojs/check": "^0.9.5",
     "@testing-library/dom": "^10.4.0",
     "@types/jsdom": "^27.0.0",
-    "astro": "^5.1.7",
+    "astro": "^6.0.0",
     "jsdom": "^27.2.0",
     "tsup": "^8.3.5",
     "vitest": "^3.0.2"
@@ -55,6 +55,6 @@
     "blurhash": "^2.0.5"
   },
   "peerDependencies": {
-    "astro": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-beta"
+    "astro": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
   }
 }


### PR DESCRIPTION
Closes #856.

This PR adds support for Astro 6 by updating the `peerDependencies` range to include `^6.0.0`.