### PR TITLE
fix(react): Don't camelize CSS variables

### DIFF
--- a/packages/react/src/camelize.ts
+++ b/packages/react/src/camelize.ts
@@ -12,7 +12,7 @@ const fixedMap: Record<string, string> = {
 };
 
 const camelize = (key: string) => {
-  if (key.startsWith("data-") || key.startsWith("aria-")) {
+  if (key.startsWith("data-") || key.startsWith("aria-") || key.startsWith("--")) {
     return key;
   }
   return (


### PR DESCRIPTION
An issue I encountered while trying to use unpic/react with Mantine as a polymorphic image component. Mantine passes some props like border radius as a css vars (for example `--image-radius`) in `styles` prop. Due to camelization it results in the following error:
```
Unsupported style property -imageRadius. Did you mean ImageRadius?
```
